### PR TITLE
chore: OSS readiness pass — scrub + contributor docs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Group all action bumps into one PR per week so the CI surface churns
+    # once per cycle instead of every action releasing independently.
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- One or two sentences on what this change does and why. -->
+
+## Type
+
+- [ ] feat — new user-visible behavior
+- [ ] fix — bug fix
+- [ ] refactor — no behavior change
+- [ ] test / docs / chore / ci
+
+## Checklist
+
+- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/).
+- [ ] `make lint` passes.
+- [ ] `make cover` passes (100% on `./internal/...`).
+- [ ] Docs / CLAUDE.md updated if behavior, flags, or file layout changed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
           filters: |
@@ -44,10 +44,10 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
@@ -77,10 +77,10 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
@@ -92,10 +92,10 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
@@ -107,10 +107,10 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
@@ -122,15 +122,15 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
       - name: Install GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,12 +34,12 @@ jobs:
     steps:
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
         with:
           app-id: ${{ secrets.HPT_BOT_APP_ID }}
           private-key: ${{ secrets.HPT_BOT_KEY }}
 
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         id: release
         with:
           token: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,20 +13,20 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: "1.25"
 
       - name: Install syft for SBOM generation
-        uses: anchore/sbom-action/download-syft@v0
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6.4.0
         with:
           distribution: goreleaser
           version: "~> v2"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,13 @@
 - `.github/workflows/` — CI (`ci.yml` + release pipeline). Docs-only PRs skip the heavy jobs; see README § "CI scope".
 - `install.sh` — curl-friendly installer that fetches the matching `ana_<version>_<os>_<arch>` archive, verifies the sha256, and drops `ana` on `PATH`.
 - `.goreleaser.yml`, `release-please-config.json`, `.release-please-manifest.json` — release pipeline config. Conventional commits drive release-please → goreleaser.
+- `CONTRIBUTING.md`, `SECURITY.md` — external-contributor onboarding + security disclosure policy. Wired into `.github/pull_request_template.md`.
 
 ## Workflow at a glance
 
 - Build / test / cover: `make build`, `make test`, `make cover` (100% coverage gate on `./internal/...`).
 - Lint: `make lint` (gofmt, go vet, staticcheck).
 - Local release smoke: `make release-local` (`goreleaser check` + `--snapshot`).
-- Live smoke tests: `make e2e` (requires `ANA_E2E_ENDPOINT` + `ANA_E2E_TOKEN`; see `e2e/README.md`).
+- Live smoke tests: `make e2e` (requires `ANA_E2E_ENDPOINT`, `ANA_E2E_TOKEN`, `ANA_E2E_EXPECT_ORG`; see `e2e/README.md`).
+- `make help` — self-documenting list of every target.
 - Capture a new endpoint: run the `textql-webapp-probe` skill — output lands in `.playwright-mcp/`, then gets emitted into `api-catalog/`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+Thanks for your interest in `ana-cli`. External contributions are
+welcome — this document covers the basics.
+
+## Prerequisites
+
+- Go 1.25 or newer.
+- `make`.
+- `goreleaser` only if you want to run `make release-local`.
+
+## Building and testing
+
+```bash
+make build    # -> ./bin/ana
+make test     # go test -race ./...
+make cover    # enforces 100% coverage on ./internal/...
+make lint     # gofmt, go vet, staticcheck
+```
+
+`make cover` runs staticcheck-pinned dev tools. Run `make deps` once to
+install them.
+
+End-to-end tests live in `e2e/` and require a live TextQL endpoint
+plus a token. They are opt-in; see [`e2e/README.md`](e2e/README.md).
+You do not need them to land most PRs.
+
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+Commit subjects drive the release pipeline (release-please →
+GoReleaser), so get the prefix right:
+
+- `feat:` — new verb, flag, or user-visible behavior.
+- `fix:` — bug fix.
+- `refactor:` — internal change, no behavior change.
+- `test:` — test-only change.
+- `docs:` — docs, README, CLAUDE.md.
+- `chore:` / `ci:` — tooling, pipeline, dependencies.
+
+Scope is optional but helpful (e.g. `fix(auth): ...`).
+
+## Pull requests
+
+- Branch off `main`, open the PR against `main`.
+- One logical change per PR. Split refactors from features.
+- CI runs lint, test on linux/macos/windows, a 100% coverage gate on
+  `./internal/...`, a build check, and `goreleaser check`. Docs-only
+  PRs skip the heavy jobs automatically.
+- Squash merge is the house style — the PR title becomes the commit
+  subject, so make it conform to Conventional Commits.
+
+## Adding a new verb
+
+Each top-level verb lives in its own package under `internal/`. The
+pattern:
+
+1. Declare a narrow `Deps` struct; do not import `internal/transport`
+   or `internal/config` — `cmd/ana/main.go` wires those in.
+2. Build a `cli.Group` from `New(deps)` and register subcommands.
+3. Write tests using the fake `Deps` pattern — see
+   `internal/feed/feed_test.go` for the convention.
+
+Coverage is gated at 100% on `./internal/...`, so every branch needs
+a test.
+
+## Questions
+
+Open a [discussion](https://github.com/highperformance-tech/ana-cli/discussions)
+or a draft PR. For security issues, see [SECURITY.md](SECURITY.md).

--- a/Makefile
+++ b/Makefile
@@ -1,24 +1,29 @@
-.PHONY: all build test cover vet lint deps release-local clean e2e e2e-sweep e2e-dryrun
+.PHONY: help all build test cover vet lint deps release-local clean e2e e2e-sweep e2e-dryrun
 
 GO ?= go
 PKGS := ./...
 STATICCHECK_VERSION := 2025.1.1
 
-all: test build
+# help prints each target's leading `##` doc comment. Keep target docs on the
+# same line as the target for awk to find them.
+help: ## Show this help.
+	@awk 'BEGIN {FS = ":.*## "; printf "Targets:\n"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-build:
+all: test build ## Run tests then build the binary.
+
+build: ## Build ./bin/ana.
 	$(GO) build -o bin/ana ./cmd/ana
 
-vet:
+vet: ## Run go vet.
 	$(GO) vet $(PKGS)
 
 # deps installs development tools pinned for reproducibility.
-deps:
+deps: ## Install pinned dev tools (staticcheck).
 	$(GO) install honnef.co/go/tools/cmd/staticcheck@$(STATICCHECK_VERSION)
 
 # lint mirrors the CI lint job: gofmt check, go vet, staticcheck. Assumes
 # `make deps` has been run at least once so staticcheck is on PATH.
-lint:
+lint: ## Run gofmt / go vet / staticcheck (mirrors CI).
 	@if [ -n "$$(gofmt -l .)" ]; then \
 		echo "Code is not formatted. Run 'go fmt ./...'"; \
 		gofmt -d .; \
@@ -30,11 +35,11 @@ lint:
 # release-local validates .goreleaser.yml and produces a throwaway snapshot
 # in dist/. Requires goreleaser on PATH (brew install goreleaser or
 # https://goreleaser.com/install/). No publish, no tag push.
-release-local:
+release-local: ## Validate goreleaser config + build a snapshot (no publish).
 	goreleaser check
 	goreleaser release --snapshot --clean
 
-test:
+test: ## Run the race-enabled test suite.
 	$(GO) test -race $(PKGS)
 
 # cover runs -race -coverprofile across ALL packages (so the race detector
@@ -42,13 +47,13 @@ test:
 # cmd/ana is intentionally excluded from the gate: it is pure wiring whose
 # uncovered lines (os.Exit, signal.NotifyContext, the main() entry itself)
 # cannot be reached from a go-test process without exec'ing a subprocess.
-cover:
+cover: ## Run tests with coverage; fail if ./internal/... drops below 100%.
 	$(GO) test -race -coverprofile=c.out $(PKGS)
 	$(GO) test -race -coverprofile=c.internal.out ./internal/...
 	$(GO) tool cover -func=c.internal.out | tail -1
 	@$(GO) tool cover -func=c.internal.out | awk '/^total:/ { split($$3, a, "%"); if (a[1]+0 < 100) { print "internal coverage below 100% ("$$3")"; exit 1 } }'
 
-clean:
+clean: ## Remove build + coverage artifacts.
 	rm -rf bin dist c.out c.internal.out
 
 ENV_FILE := .env
@@ -64,15 +69,15 @@ LOAD_ENV := if [ -f $(ENV_FILE) ]; then set -a; . ./$(ENV_FILE); set +a; fi;
 #   ANA_E2E_EXPECT_ORG human-readable org name the token must resolve to
 # -p 1 serializes packages so parallel resource names cannot collide; the
 # suite uses disposable-parent-nesting to stay auto-revertable.
-e2e:
+e2e: ## Run live e2e tests against app.textql.com (requires ANA_E2E_* env).
 	@$(LOAD_ENV) $(GO) test -p 1 -count=1 -timeout 10m ./e2e/...
 
 # e2e-dryrun lists every planned mutation without hitting the network. The
 # harness short-circuits Run() and returns empty results; see harness/harness.go.
-e2e-dryrun:
+e2e-dryrun: ## List planned e2e mutations without hitting the network.
 	@$(LOAD_ENV) ANA_E2E_DRYRUN=1 $(GO) test -p 1 -count=1 -timeout 2m -v ./e2e/...
 
 # e2e-sweep cleans any anacli-e2e-* leftovers from prior crashed runs. Useful
 # to run manually before a fresh suite if a previous run died mid-test.
-e2e-sweep:
+e2e-sweep: ## Clean up anacli-e2e-* leftovers from prior crashed runs.
 	@$(LOAD_ENV) ANA_E2E_SWEEP_ONLY=1 $(GO) test -p 1 -count=1 -timeout 2m ./e2e/...

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,36 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for security-sensitive reports.
+
+Email `security@highperformance.tech` with:
+
+- A description of the issue and the impact you can reproduce.
+- Steps to reproduce (command, environment, observed vs. expected).
+- Whether the vulnerability involves credentials, a release artifact,
+  the install script, or the CLI itself.
+
+You will receive an acknowledgement within three business days. We
+coordinate disclosure privately and credit reporters in the release
+notes unless anonymity is requested.
+
+## Scope
+
+In scope:
+
+- The `ana` binary and any code under `cmd/` or `internal/`.
+- The release pipeline (GoReleaser, release-please) and the
+  published archives / checksums.
+- `install.sh` and anything it fetches or verifies.
+
+Out of scope:
+
+- Vulnerabilities in the TextQL server surface that `ana` talks to.
+  Report those directly to TextQL.
+- Third-party dependencies with upstream advisories already filed.
+
+## Supported versions
+
+Only the latest minor release receives security fixes. Older tags are
+left in place for reproducibility but are not patched.

--- a/docs/features.md
+++ b/docs/features.md
@@ -128,7 +128,7 @@ Per-endpoint request/response schemas live in `api-catalog/` (~85 endpoints as o
 
 ## Datasets
 
-- **Entity:** `Dataset` — queryable collection scoped to a connector (e.g. "Superstore Dataset" under `tableau.hpt.tools`).
+- **Entity:** `Dataset` — queryable collection scoped to a connector (e.g. "Superstore Dataset" under `tableau.example.com`).
 - **Service:** `dataset.DatasetService`
 - **Methods:** `GetDatasets` (called with different scopes).
 - **Last verified:** 2026-04-17

--- a/internal/feed/stats_test.go
+++ b/internal/feed/stats_test.go
@@ -26,7 +26,7 @@ func TestStatsTable(t *testing.T) {
 				"threadsCreated":       399,
 				"playbooksCreated":     5,
 				"connectorsConfigured": 4,
-				"connectorNames":       []any{"HPT", "tableau.hpt.tools"},
+				"connectorNames":       []any{"HPT", "tableau.example.com"},
 				"activeAgentNames":     []any{"AWS Inspector"},
 			}
 			return nil
@@ -60,7 +60,7 @@ func TestStatsTable(t *testing.T) {
 		"threadsCreated":       "399",
 		"playbooksCreated":     "5",
 		"connectorsConfigured": "4",
-		"connectorNames":       "HPT, tableau.hpt.tools",
+		"connectorNames":       "HPT, tableau.example.com",
 		"activeAgentNames":     "AWS Inspector",
 	} {
 		if !rowHas(label, value) {


### PR DESCRIPTION
## Summary

Pre-public-flip cleanup from three subagent audits (security, embarrassment, dev-practices).

- Scrub `tableau.hpt.tools` internal hostname from test fixture + docs.
- Add `SECURITY.md` (disclosure policy) and `CONTRIBUTING.md` (build/test/PR flow).
- Add minimal `.github/pull_request_template.md`.
- Add self-documenting `make help` target with per-target `##` docs.
- Stale CLAUDE.md hint corrected: `make e2e` needs `ANA_E2E_EXPECT_ORG` too.

## Still open (needs owner decision before public flip)

1. **Git history** — `tableau.hpt.tools` remains in three historical commits (`9de1325`, `e3616a7`, `0bc57f0`). Prior anonymization (`f5cface`) targeted `api-catalog/` only. Force-rewrite again or accept.
2. **`release.yml` on `workflow_dispatch`** — no environment gate, any repo writer can trigger a release. Consider `environment: release` with required reviewer.
3. **Action pinning** — workflows use floating `@v4` / `@v5` tags. Pin to commit SHAs + Dependabot action-updates.
4. **`install.sh` trust anchor** — `checksums.txt` fetched from same origin as archive. Consider GoReleaser `signs:` (minisign / cosign) so install can verify a pinned key.

## Type

- [x] chore / docs

## Checklist

- [x] Conventional Commits.
- [x] `make lint` passes locally.
- [x] `make cover` still 100% on `./internal/...`.
- [x] Root `CLAUDE.md` updated for the new top-level files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated test assertions to expect a corrected connector host value.

* **Chores**
  * Added a help target and inline documentation for development targets.
  * Added Dependabot configuration to monitor workflow/action updates.
  * Pinned CI and release workflow action references to fixed commits for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->