### PR TITLE
refactor(connector): extract shared wire types

### DIFF
--- a/internal/connector/CLAUDE.md
+++ b/internal/connector/CLAUDE.md
@@ -5,6 +5,7 @@ The `ana connector` verb tree: `list`, `get`, `create`, `update`, `delete`, `tes
 ## Files
 
 - `connector.go` — `New`, `Deps`, service path prefix.
+- `types.go` — shared wire shapes consumed by create + update: `createReq`, `updateReq`, `configEnvelope`, `postgresSpec`, `createResp`, `getConnectorResp`. Per-dialect spec types will land alongside (`types_snowflake.go`, etc.) as new dialects are probed.
 - `list.go` / `get.go` — `GetConnectors` / `GetConnector` (readonly).
 - `create.go` — `CreateConnector`. Postgres dialect verified; other dialects assumed from captured samples.
 - `update.go` — `UpdateConnector`. Pre-fetches the baseline so interleaved flags merge correctly (see commit `1433e01`).

--- a/internal/connector/create.go
+++ b/internal/connector/create.go
@@ -17,39 +17,6 @@ func (c *createCmd) Help() string {
 		"Usage: ana connector create --type postgres --name <name> --host <h> --port <p> --user <u> (--password-stdin|--password <p>) --database <db> [--ssl]"
 }
 
-// createReq mirrors the exact wire shape captured in the API catalog. Field
-// names are protobuf camelCase; anything else is rejected server-side.
-type createReq struct {
-	Config configEnvelope `json:"config"`
-}
-
-// configEnvelope is also used by update; see update.go. The Postgres pointer
-// so we can omit the block when no postgres flags were set (update's partial
-// case).
-type configEnvelope struct {
-	ConnectorType string        `json:"connectorType,omitempty"`
-	Name          string        `json:"name,omitempty"`
-	Postgres      *postgresSpec `json:"postgres,omitempty"`
-}
-
-// postgresSpec matches the oneof leaf for the POSTGRES dialect. Port is an int
-// per the catalog; sslMode is a boolean named `sslMode` (not `ssl`).
-type postgresSpec struct {
-	Host     string `json:"host,omitempty"`
-	Port     int    `json:"port,omitempty"`
-	User     string `json:"user,omitempty"`
-	Password string `json:"password,omitempty"`
-	Database string `json:"database,omitempty"`
-	SSLMode  bool   `json:"sslMode,omitempty"`
-}
-
-// createResp is the `{connectorId, name, connectorType}` captured response.
-type createResp struct {
-	ConnectorID   int    `json:"connectorId"`
-	Name          string `json:"name"`
-	ConnectorType string `json:"connectorType"`
-}
-
 func (c *createCmd) Run(ctx context.Context, args []string, stdio cli.IO) error {
 	fs := cli.NewFlagSet("connector create")
 	var typ string

--- a/internal/connector/types.go
+++ b/internal/connector/types.go
@@ -1,0 +1,56 @@
+package connector
+
+// Shared wire types for the Connect-RPC Connector service. Field names follow
+// the captured API shapes in `api-catalog/`; anything else is rejected
+// server-side. Kept in one file so per-dialect files only need to add their
+// own `<dialect>Spec` struct and point configEnvelope at it.
+
+// createReq mirrors the exact wire shape captured in the API catalog.
+type createReq struct {
+	Config configEnvelope `json:"config"`
+}
+
+// updateReq's `connectorId` MUST sit at the top level — putting it inside
+// config returns 500 "could not find connector" (captured regression).
+type updateReq struct {
+	ConnectorID int            `json:"connectorId"`
+	Config      configEnvelope `json:"config"`
+}
+
+// configEnvelope is shared by create + update. The Postgres pointer is a
+// pointer (not a value) so update can omit the block when no postgres flags
+// were set (partial-update case).
+type configEnvelope struct {
+	ConnectorType string        `json:"connectorType,omitempty"`
+	Name          string        `json:"name,omitempty"`
+	Postgres      *postgresSpec `json:"postgres,omitempty"`
+}
+
+// postgresSpec matches the oneof leaf for the POSTGRES dialect. Port is an int
+// per the catalog; sslMode is a boolean named `sslMode` (not `ssl`).
+type postgresSpec struct {
+	Host     string `json:"host,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	User     string `json:"user,omitempty"`
+	Password string `json:"password,omitempty"`
+	Database string `json:"database,omitempty"`
+	SSLMode  bool   `json:"sslMode,omitempty"`
+}
+
+// createResp is the `{connectorId, name, connectorType}` captured response.
+type createResp struct {
+	ConnectorID   int    `json:"connectorId"`
+	Name          string `json:"name"`
+	ConnectorType string `json:"connectorType"`
+}
+
+// getConnectorResp narrows the GetConnector response to the fields the update
+// flow needs to merge as a baseline. PostgresMetadata carries host/port/user/
+// database/sslMode (no password — the server keeps that secret).
+type getConnectorResp struct {
+	Connector struct {
+		ConnectorType    string       `json:"connectorType"`
+		Name             string       `json:"name"`
+		PostgresMetadata postgresSpec `json:"postgresMetadata"`
+	} `json:"connector"`
+}

--- a/internal/connector/update.go
+++ b/internal/connector/update.go
@@ -19,24 +19,6 @@ func (c *updateCmd) Help() string {
 		"Usage: ana connector update <id> [--type postgres] [--name ...] [--host ...] [--port ...] [--user ...] [--database ...] [--password ...|--password-stdin] [--ssl]"
 }
 
-// updateReq's `connectorId` MUST sit at the top level — putting it inside
-// config returns 500 "could not find connector" (captured regression).
-type updateReq struct {
-	ConnectorID int            `json:"connectorId"`
-	Config      configEnvelope `json:"config"`
-}
-
-// getConnectorResp narrows the GetConnector response to the fields the update
-// flow needs to merge as a baseline. PostgresMetadata carries host/port/user/
-// database/sslMode (no password — the server keeps that secret).
-type getConnectorResp struct {
-	Connector struct {
-		ConnectorType    string       `json:"connectorType"`
-		Name             string       `json:"name"`
-		PostgresMetadata postgresSpec `json:"postgresMetadata"`
-	} `json:"connector"`
-}
-
 func (c *updateCmd) Run(ctx context.Context, args []string, stdio cli.IO) error {
 	fs := cli.NewFlagSet("connector update")
 	typ := fs.String("type", "", "connector type (postgres)")


### PR DESCRIPTION
## Summary

Pure relocation of connector wire types out of create.go / update.go into a new types.go:

- `createReq`, `updateReq`, `configEnvelope`, `postgresSpec`, `createResp`, `getConnectorResp`.

No behavioral change. Sets up the seam for per-dialect spec types (`types_snowflake.go`, `types_databricks.go`) without churning create.go or update.go.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization improvements for connector operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->