### PR TITLE
docs(readme): distinguish signed release binaries from unsigned source builds in SmartScreen section

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,14 @@ make build
 
 ### Windows SmartScreen
 
-The Windows binary is unsigned. On first run SmartScreen may block it with
-"Windows protected your PC". Click **More info → Run anyway**. To avoid the
-prompt altogether, unblock the executable before running:
+Release binaries are Authenticode-signed with Azure Trusted Signing (see the
+`sign-windows` job in `.github/workflows/release.yml`), so SmartScreen should
+not prompt for official downloads from GitHub Releases.
+
+If you build from source (`go install` / `make build`), the resulting
+`ana.exe` is **not** signed and SmartScreen may still block it on first run
+with "Windows protected your PC". Click **More info → Run anyway**, or
+unblock the file before running:
 
 ```powershell
 Unblock-File -Path .\ana.exe


### PR DESCRIPTION
## Summary

Per #8, the README's Windows SmartScreen section told users the Windows binary was unsigned and would trigger SmartScreen. Meanwhile, \`.github/workflows/release.yml\` runs a \`sign-windows\` job that Authenticode-signs both amd64 and arm64 Windows executables via Azure Trusted Signing before packaging — so GitHub Release downloads should **not** prompt.

Reworded the section to keep the accurate info (source builds remain unsigned, Unblock-File guidance still helpful for those cases) while correcting the claim for release binaries.

Closes #8

## Testing

Docs-only change.