### PR TITLE
fix(connector): test verb fetches config via GetConnector before probing

### DIFF
--- a/internal/connector/test.go
+++ b/internal/connector/test.go
@@ -4,26 +4,21 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/highperformance-tech/ana-cli/internal/cli"
 )
 
 // testCmd implements `ana connector test <id>` — TestConnector.
 //
-// CATALOG DEVIATION: the task brief specifies
-//
-//	POST TestConnector {"connectorId": <int>}
-//
-// but the captured API requires a full config body:
-//
-//	POST TestConnector {"config": {connectorType, name, postgres: {...}}}
-//
-// (see api-catalog/POST_...TestConnector.json). Since the brief says "if
-// catalog differs from this brief, prefer catalog," we follow the catalog
-// shape and send `{connectorId}` anyway — this matches the brief's CLI UX
-// (test-by-id) and will either be accepted by a future server change or
-// return the current driver error, which we surface verbatim. Server response
-// shape `{error: <string>}` is empty/absent on success.
+// CATALOG REALITY: the server's TestConnector endpoint validates a full config
+// body (`{config: {connectorType, name, <dialect>: {...}}}`), not a bare id —
+// it's a pre-create probe, not a test-existing op. To preserve the CLI's
+// id-based UX we GET the connector first, rebuild a config from the returned
+// `<dialect>Metadata` block, and POST that to TestConnector. Passwords/secrets
+// are redacted in GetConnector responses, so the dial typically fails with an
+// auth or connection error — which the server still returns as a 200 with the
+// driver message in `error`. Both `OK` and `FAIL: <msg>` are valid CLI outputs.
 type testCmd struct{ deps Deps }
 
 func (c *testCmd) Help() string {
@@ -32,7 +27,7 @@ func (c *testCmd) Help() string {
 }
 
 type testReq struct {
-	ConnectorID int `json:"connectorId"`
+	Config map[string]any `json:"config"`
 }
 
 type testResp struct {
@@ -51,8 +46,16 @@ func (c *testCmd) Run(ctx context.Context, args []string, stdio cli.IO) error {
 	if err != nil {
 		return err
 	}
+	var getRaw map[string]any
+	if err := c.deps.Unary(ctx, servicePath+"/GetConnector", getReq{ConnectorID: id}, &getRaw); err != nil {
+		return fmt.Errorf("connector test: %w", err)
+	}
+	cfg, err := configFromGetConnector(getRaw)
+	if err != nil {
+		return fmt.Errorf("connector test: %w", err)
+	}
 	var raw map[string]any
-	if err := c.deps.Unary(ctx, servicePath+"/TestConnector", testReq{ConnectorID: id}, &raw); err != nil {
+	if err := c.deps.Unary(ctx, servicePath+"/TestConnector", testReq{Config: cfg}, &raw); err != nil {
 		return fmt.Errorf("connector test: %w", err)
 	}
 	var typed testResp
@@ -67,4 +70,40 @@ func (c *testCmd) Run(ctx context.Context, args []string, stdio cli.IO) error {
 		return fmt.Errorf("connector test: %w", err)
 	}
 	return nil
+}
+
+// configFromGetConnector rebuilds a TestConnector `config` body from a
+// GetConnector response. It copies the top-level `name` + `connectorType`, and
+// moves the `<dialect>Metadata` block into `<dialect>`. Secrets are absent
+// from the metadata block; the server accepts the probe and returns a driver
+// error for the missing credential.
+func configFromGetConnector(raw map[string]any) (map[string]any, error) {
+	conn, _ := raw["connector"].(map[string]any)
+	if conn == nil {
+		return nil, fmt.Errorf("GetConnector: missing connector object")
+	}
+	connectorType, _ := conn["connectorType"].(string)
+	name, _ := conn["name"].(string)
+	if connectorType == "" {
+		return nil, fmt.Errorf("GetConnector: missing connectorType")
+	}
+	cfg := map[string]any{"connectorType": connectorType, "name": name}
+	for k, v := range conn {
+		if !strings.HasSuffix(k, "Metadata") {
+			continue
+		}
+		if block, ok := v.(map[string]any); ok {
+			dialectKey := strings.TrimSuffix(k, "Metadata")
+			// GetConnector redacts secrets, so fill a placeholder for any
+			// required secret field. The server returns the driver's auth
+			// failure as a 200 `{error: ...}` which the CLI surfaces as FAIL:.
+			for _, secret := range []string{"password"} {
+				if _, present := block[secret]; !present {
+					block[secret] = "redacted"
+				}
+			}
+			cfg[dialectKey] = block
+		}
+	}
+	return cfg, nil
 }

--- a/internal/connector/test.go
+++ b/internal/connector/test.go
@@ -94,15 +94,20 @@ func configFromGetConnector(raw map[string]any) (map[string]any, error) {
 		}
 		if block, ok := v.(map[string]any); ok {
 			dialectKey := strings.TrimSuffix(k, "Metadata")
+			// Shallow-copy so we never mutate the caller's map.
+			out := make(map[string]any, len(block)+1)
+			for bk, bv := range block {
+				out[bk] = bv
+			}
 			// GetConnector redacts secrets, so fill a placeholder for any
 			// required secret field. The server returns the driver's auth
 			// failure as a 200 `{error: ...}` which the CLI surfaces as FAIL:.
 			for _, secret := range []string{"password"} {
-				if _, present := block[secret]; !present {
-					block[secret] = "redacted"
+				if _, present := out[secret]; !present {
+					out[secret] = "redacted"
 				}
 			}
-			cfg[dialectKey] = block
+			cfg[dialectKey] = out
 		}
 	}
 	return cfg, nil

--- a/internal/connector/test.go
+++ b/internal/connector/test.go
@@ -102,6 +102,12 @@ func configFromGetConnector(raw map[string]any) (map[string]any, error) {
 			// GetConnector redacts secrets, so fill a placeholder for any
 			// required secret field. The server returns the driver's auth
 			// failure as a 200 `{error: ...}` which the CLI surfaces as FAIL:.
+			// NOTE: only "password" is placeholdered today. Postgres uses it;
+			// Snowflake's non-password auth modes (keypair, oauth-sso,
+			// oauth-individual) use privateKey / oauthClientSecret and will
+			// still surface a driver-side auth error via the same FAIL: path
+			// — extend this slice when adding a dialect whose TestConnector
+			// body requires a different secret field name.
 			for _, secret := range []string{"password"} {
 				if _, present := out[secret]; !present {
 					out[secret] = "redacted"

--- a/internal/connector/test_test.go
+++ b/internal/connector/test_test.go
@@ -10,10 +10,28 @@ import (
 	"github.com/highperformance-tech/ana-cli/internal/testcli"
 )
 
+// stubGetConnector returns a minimal GetConnector response so `connector test`
+// can build a config body for the follow-up TestConnector call.
+func stubGetConnector(resp any) {
+	out := resp.(*map[string]any)
+	*out = map[string]any{
+		"connector": map[string]any{
+			"id":               1.0,
+			"name":             "probe",
+			"connectorType":    "POSTGRES",
+			"postgresMetadata": map[string]any{"host": "h", "port": 5432.0, "user": "u", "database": "d", "dialect": "postgres", "sslMode": true},
+		},
+	}
+}
+
 func TestTestOK(t *testing.T) {
 	t.Parallel()
 	f := &fakeDeps{
-		unaryFn: func(_ context.Context, _ string, _, resp any) error {
+		unaryFn: func(_ context.Context, path string, _, resp any) error {
+			if strings.HasSuffix(path, "/GetConnector") {
+				stubGetConnector(resp)
+				return nil
+			}
 			out := resp.(*map[string]any)
 			*out = map[string]any{"error": ""}
 			return nil
@@ -35,7 +53,11 @@ func TestTestOK(t *testing.T) {
 func TestTestFail(t *testing.T) {
 	t.Parallel()
 	f := &fakeDeps{
-		unaryFn: func(_ context.Context, _ string, _, resp any) error {
+		unaryFn: func(_ context.Context, path string, _, resp any) error {
+			if strings.HasSuffix(path, "/GetConnector") {
+				stubGetConnector(resp)
+				return nil
+			}
 			out := resp.(*map[string]any)
 			*out = map[string]any{"error": "connection refused"}
 			return nil
@@ -54,7 +76,11 @@ func TestTestFail(t *testing.T) {
 func TestTestJSON(t *testing.T) {
 	t.Parallel()
 	f := &fakeDeps{
-		unaryFn: func(_ context.Context, _ string, _, resp any) error {
+		unaryFn: func(_ context.Context, path string, _, resp any) error {
+			if strings.HasSuffix(path, "/GetConnector") {
+				stubGetConnector(resp)
+				return nil
+			}
 			out := resp.(*map[string]any)
 			*out = map[string]any{"error": ""}
 			return nil
@@ -115,7 +141,11 @@ func TestTestBadFlag(t *testing.T) {
 func TestTestRemarshalErr(t *testing.T) {
 	t.Parallel()
 	f := &fakeDeps{
-		unaryFn: func(_ context.Context, _ string, _, resp any) error {
+		unaryFn: func(_ context.Context, path string, _, resp any) error {
+			if strings.HasSuffix(path, "/GetConnector") {
+				stubGetConnector(resp)
+				return nil
+			}
 			out := resp.(*map[string]any)
 			*out = map[string]any{"error": 123.0}
 			return nil
@@ -125,6 +155,59 @@ func TestTestRemarshalErr(t *testing.T) {
 	stdio, _, _ := testcli.NewIO(strings.NewReader(""))
 	err := cmd.Run(context.Background(), []string{"1"}, stdio)
 	if err == nil || !strings.Contains(err.Error(), "decode response") {
+		t.Errorf("err=%v", err)
+	}
+}
+
+func TestTestTestConnectorUnaryErr(t *testing.T) {
+	t.Parallel()
+	f := &fakeDeps{
+		unaryFn: func(_ context.Context, path string, _, resp any) error {
+			if strings.HasSuffix(path, "/GetConnector") {
+				stubGetConnector(resp)
+				return nil
+			}
+			return errors.New("boom")
+		},
+	}
+	cmd := &testCmd{deps: f.deps()}
+	stdio, _, _ := testcli.NewIO(strings.NewReader(""))
+	err := cmd.Run(context.Background(), []string{"1"}, stdio)
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Errorf("err=%v", err)
+	}
+}
+
+func TestTestMissingConnectorType(t *testing.T) {
+	t.Parallel()
+	f := &fakeDeps{
+		unaryFn: func(_ context.Context, _ string, _, resp any) error {
+			out := resp.(*map[string]any)
+			*out = map[string]any{"connector": map[string]any{"id": 1.0}}
+			return nil
+		},
+	}
+	cmd := &testCmd{deps: f.deps()}
+	stdio, _, _ := testcli.NewIO(strings.NewReader(""))
+	err := cmd.Run(context.Background(), []string{"1"}, stdio)
+	if err == nil || !strings.Contains(err.Error(), "missing connectorType") {
+		t.Errorf("err=%v", err)
+	}
+}
+
+func TestTestMissingConnector(t *testing.T) {
+	t.Parallel()
+	f := &fakeDeps{
+		unaryFn: func(_ context.Context, _ string, _, resp any) error {
+			out := resp.(*map[string]any)
+			*out = map[string]any{}
+			return nil
+		},
+	}
+	cmd := &testCmd{deps: f.deps()}
+	stdio, _, _ := testcli.NewIO(strings.NewReader(""))
+	err := cmd.Run(context.Background(), []string{"1"}, stdio)
+	if err == nil || !strings.Contains(err.Error(), "missing connector object") {
 		t.Errorf("err=%v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- `ana connector test <id>` previously sent `{connectorId: <int>}` which the server rejected (`invalid value for string field connectorId` and, after stringifying, `config is required`). The TestConnector RPC validates a full `{config: {...}}` body — it's a pre-create probe, not a test-by-id op.
- The verb now does GetConnector first, rebuilds the config from the returned `<dialect>Metadata` block, and posts that to TestConnector. The CLI surface stays id-only.
- GetConnector redacts secrets, so the dialect block gets `password: "redacted"` so config validation passes; the driver returns its real auth/dial error via the standard `{error: ...}` shape and the CLI surfaces it as `FAIL: <msg>` (unchanged contract).

## Validation
- `./internal/...` coverage gate stays at 100.0%.
- Live `TestConnectorTest` in the e2e suite (PR #18) flips from FAIL to PASS once this lands.

## Test plan
- [x] `make lint`
- [x] `make cover` (100.0%)
- [x] Live `go test -v ./e2e/ -run TestConnectorTest$` against the demo org → PASS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `connector test` now retrieves full connector metadata before testing, improving validation and ensuring complete configuration is used.
  * Improved error handling for missing connector details and failed follow-up retrievals; errors are now clearer and wrapped.
  * Missing credentials are handled by inserting a safe placeholder during test construction.

* **Tests**
  * Added tests covering retrieval failures, absent connector objects, missing connector types, and related error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->