### PR TITLE
ci(release): keep 0.x bumps pre-major

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,9 @@
     ".": {
       "release-type": "go",
       "package-name": "ana-cli",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true
     }
   }
 }


### PR DESCRIPTION
## Summary
- Open release-please PR bumped to 1.0.0 because of `refactor(connector)!` in #15 — `!` = breaking, default behavior jumps to major.
- Not ready for v1. Enable `bump-minor-pre-major` + `bump-patch-for-minor-pre-major` so breaking on 0.x bumps minor (0.3.0) and feat bumps patch.
- After merge, release-please will recompute and replace the existing 1.0.0 PR with a 0.3.0 one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings for improved version management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->