### PR TITLE
ci: rename deprecated app-id input to client-id

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -36,7 +36,7 @@ jobs:
         id: generate-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.HPT_BOT_APP_ID }}
+          client-id: ${{ secrets.HPT_BOT_APP_ID }}
           private-key: ${{ secrets.HPT_BOT_KEY }}
 
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1


### PR DESCRIPTION
## Summary

- Rename `app-id` → `client-id` on `actions/create-github-app-token` in `release-please.yml` to clear the deprecation warning.
- Secret name `HPT_BOT_APP_ID` is unchanged; only the workflow input key moves.

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow configuration for GitHub App token generation in the release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->